### PR TITLE
Feat: 뷰포트에 보이는 리스트 아이템 감지 커스텀 훅 구현

### DIFF
--- a/digital_game_nomad/shared/hooks/useIntersectionVisibility.ts
+++ b/digital_game_nomad/shared/hooks/useIntersectionVisibility.ts
@@ -1,0 +1,85 @@
+// package
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+// slice
+import { UseIntersectionVisibilityOptions } from '../types';
+
+export function useIntersectionVisibility<T extends HTMLElement>(
+  dataLength: number,
+  options?: UseIntersectionVisibilityOptions
+) {
+  const [visibleItems, setVisibleItems] = useState<Set<number>>(new Set());
+
+  const itemRefs = useRef<(T | null)[]>([]);
+
+  const handleIntersect = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          const id = parseInt(
+            (entry.target as T).getAttribute('data-id') || '0'
+          );
+          setVisibleItems((prev) => {
+            if (!prev.has(id)) {
+              const newSet = new Set(prev);
+              newSet.add(id);
+              return newSet;
+            }
+            return prev;
+          });
+        }
+      });
+    },
+    []
+  );
+
+  useEffect(() => {
+    const defaultObserver = new IntersectionObserver(handleIntersect, {
+      root: options?.root || null,
+      rootMargin: options?.rootMargin || '0px 0px -10% 0px',
+      threshold: options?.threshold || 0.1,
+    });
+
+    let lastItemObserver: IntersectionObserver | undefined;
+
+    if (
+      options?.offsetForLastItems !== undefined &&
+      options.offsetForLastItems > 0
+    ) {
+      lastItemObserver = new IntersectionObserver(handleIntersect, {
+        root: options?.root || null,
+        rootMargin: '0px 0px 20% 0px',
+        threshold: 0,
+      });
+    }
+
+    setVisibleItems(new Set());
+
+    itemRefs.current.forEach((ref, index) => {
+      if (ref) {
+        if (
+          lastItemObserver &&
+          options?.offsetForLastItems !== undefined &&
+          index >= dataLength - options.offsetForLastItems
+        ) {
+          lastItemObserver.observe(ref);
+        } else {
+          defaultObserver.observe(ref);
+        }
+      }
+    });
+
+    return () => {
+      defaultObserver.disconnect();
+      if (lastItemObserver) {
+        lastItemObserver.disconnect();
+      }
+    };
+  }, [handleIntersect, dataLength, options]);
+
+  const setItemRef = useCallback((el: T | null, id: number) => {
+    itemRefs.current[id - 1] = el;
+  }, []);
+
+  return { visibleItems, setItemRef };
+}

--- a/digital_game_nomad/shared/types/index.ts
+++ b/digital_game_nomad/shared/types/index.ts
@@ -1,0 +1,15 @@
+export type UseIntersectionVisibilityOptions = {
+  root?: Element | null;
+  rootMargin?: string;
+  threshold?: number | number[];
+  offsetForLastItems?: number;
+};
+
+export type AnimatedBackgroundProps = {
+  children?: React.ReactNode;
+  variant?: 'default' | 'blue' | 'purple';
+  intensity?: 'subtle' | 'default' | 'intense';
+  position?: 'relative' | 'fixed' | 'absolute';
+  fullscreen?: boolean;
+  className?: string;
+};


### PR DESCRIPTION
### 작업 내용
- Intersection Observer를 활용해 아이템별로 화면에 보이는 상태 관리

- 마지막 N개 아이템에 대해 별도의 옵저버 옵션 적용 가능

- 옵션으로 루트 엘리먼트, 마진, 임계값 등 지정 가능

- 보이는 아이템의 ID를 Set으로 관리하여 상태 제공