### PR TITLE
Feat: 스크롤을 최상단으로 이동시키는 ScrollToTop 구현

### DIFF
--- a/digital_game_nomad/shared/components/ScrollToTopInitializer/index.tsx
+++ b/digital_game_nomad/shared/components/ScrollToTopInitializer/index.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+// slice
+import { useScrollToTopOnRouteChange } from '../../hooks/useScrollToTopOnRouteChange';
+
+export default function ScrollToTopInitializer() {
+  useScrollToTopOnRouteChange('smooth');
+  return null;
+}

--- a/digital_game_nomad/shared/hooks/useScrollToTop.ts
+++ b/digital_game_nomad/shared/hooks/useScrollToTop.ts
@@ -1,0 +1,17 @@
+// package
+import { useEffect } from 'react';
+
+// slice
+import { ScrollBehavior } from '../types';
+
+export function useScrollToTop(
+  dependency: any,
+  behavior: ScrollBehavior = 'smooth'
+) {
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: behavior,
+    });
+  }, [dependency, behavior]);
+}

--- a/digital_game_nomad/shared/hooks/useScrollToTopOnRouteChange.ts
+++ b/digital_game_nomad/shared/hooks/useScrollToTopOnRouteChange.ts
@@ -1,0 +1,23 @@
+'use client';
+
+// package
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+// slice
+import { ScrollBehavior } from '../types';
+
+export function useScrollToTopOnRouteChange(
+  behavior: ScrollBehavior = 'smooth'
+) {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.scrollTo({
+        top: 0,
+        behavior: behavior,
+      });
+    }
+  }, [pathname, behavior]);
+}

--- a/digital_game_nomad/shared/types/index.ts
+++ b/digital_game_nomad/shared/types/index.ts
@@ -32,3 +32,5 @@ export type PasswordToggleButtonProps = {
 export type SpinnerProps = {
   message?: string;
 };
+
+export type ScrollBehavior = 'auto' | 'smooth';


### PR DESCRIPTION
### 작업 내용

- 라우트가 변경될 때마다 스크롤 위치를 최상단으로 이동시키는 공용 훅 및 초기화 컴포넌트 구현

- usePathname을 활용하여 경로가 변경되는 시점을 감지

- 스크롤 이동 애니메이션은 'auto'와 'smooth' 중 선택 가능하며, 기본값은 'smooth'로 설정

- 타입 정의와 훅, 초기화용 컴포넌트 등 내부에서 공통적으로 사용할 수 있도록 분리하여 구성

- 라우트가 변경되지 않거나(=최초 진입 등) 명시적 호출이 필요없는 경우 불필요한 스크롤 이동 없음