### PR TITLE
Feat: 게시글 수정 페이지 동작 로직 구현

### DIFF
--- a/digital_game_nomad/app/board/(posts)/edit/constants/index.ts
+++ b/digital_game_nomad/app/board/(posts)/edit/constants/index.ts
@@ -1,0 +1,14 @@
+export const MESSAGES = {
+  LOADING_POST: '게시글을 불러오는 중...',
+  POST_NOT_FOUND_TITLE: '수정할 게시글을 찾을 수 없습니다.',
+  POST_NOT_FOUND_MESSAGE: 'URL이 올바른지 확인해주세요.',
+};
+
+export const BUTTON_TEXT = {
+  GO_BACK: '돌아가기',
+};
+
+export const REQUIREMENT_TEXT = {
+  REQUIRED: '(필수)',
+  OPTIONAL: '(선택사항)',
+};

--- a/digital_game_nomad/app/board/(posts)/edit/containers/Edit.container.tsx
+++ b/digital_game_nomad/app/board/(posts)/edit/containers/Edit.container.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+// slice
+import EditPresenter from '../presenters/Edit.presenter';
+import Empty from '../../components/Empty';
+import { useEditForm } from '../hooks/useEditForm';
+import { PostEditProps } from '../types';
+
+// layer
+import LoadingSpinner from '@/shared/components/Spinner';
+import { useInteractiveStarRating } from '@/features/starrating';
+import { BUTTON_TEXT, MESSAGES, REQUIREMENT_TEXT } from '../constants';
+
+export default function EditContainer({
+  postId,
+  onSave,
+  onCancel,
+}: PostEditProps) {
+  const {
+    loading,
+    saving,
+    title,
+    setTitle,
+    content,
+    setContent,
+    originalData,
+    selectedGame,
+    setSelectedGame,
+    rating,
+    setGameSelectionRating,
+    isReviewMode,
+    currentImageUrl,
+    handleImageChange,
+    handleRemoveImage,
+    handleSubmit,
+    handleCancel,
+    gameList,
+  } = useEditForm({ postId, onSave, onCancel });
+
+  const {
+    currentRating: interactiveScore,
+    hoverRating,
+    processedStars,
+    handleStarClick,
+    handleStarMouseEnter,
+    handleStarMouseLeave,
+  } = useInteractiveStarRating({
+    initialRating: rating,
+    onRatingChange: setGameSelectionRating,
+    maxRating: 5,
+  });
+
+  if (loading) {
+    return <LoadingSpinner message={MESSAGES.LOADING_POST} />;
+  }
+
+  if (!originalData && postId) {
+    return (
+      <Empty
+        title={MESSAGES.POST_NOT_FOUND_TITLE}
+        message={MESSAGES.POST_NOT_FOUND_MESSAGE}
+        buttonText={BUTTON_TEXT.GO_BACK}
+        onButtonClick={handleCancel}
+      />
+    );
+  }
+
+  const typeAndGameCurrentRating = interactiveScore;
+  const typeAndGameDisplayRequirementText = isReviewMode
+    ? REQUIREMENT_TEXT.REQUIRED
+    : REQUIREMENT_TEXT.OPTIONAL;
+  const typeAndGameIsSelectFieldRequired = isReviewMode;
+
+  return (
+    <EditPresenter
+      title={title}
+      setTitle={setTitle}
+      content={content}
+      setContent={setContent}
+      topic={isReviewMode ? '후기' : '자유'}
+      currentImageUrl={currentImageUrl}
+      handleImageChange={handleImageChange}
+      handleRemoveImage={handleRemoveImage}
+      handleSubmit={handleSubmit}
+      handleCancel={handleCancel}
+      saving={saving}
+      isReviewMode={isReviewMode}
+      typeAndGameProps={{
+        mode: 'edit',
+        gameName: selectedGame,
+        setGameName: setSelectedGame,
+        gameList: gameList,
+        isReviewMode: isReviewMode,
+        currentRating: typeAndGameCurrentRating,
+        displayRequirementText: typeAndGameDisplayRequirementText,
+        isSelectFieldRequired: typeAndGameIsSelectFieldRequired,
+        hoverRating: hoverRating,
+        processedStars: processedStars,
+        handleStarClick: handleStarClick,
+        handleStarMouseEnter: handleStarMouseEnter,
+        handleStarMouseLeave: handleStarMouseLeave,
+      }}
+    />
+  );
+}

--- a/digital_game_nomad/app/board/(posts)/edit/hooks/useEditForm.ts
+++ b/digital_game_nomad/app/board/(posts)/edit/hooks/useEditForm.ts
@@ -1,0 +1,174 @@
+// package
+import { useState, useEffect, useCallback } from 'react';
+
+// slice
+import { UseEditFormProps } from '../types';
+import { useFormValidation } from '../../hooks/useFormValidation';
+import { useGameSelection } from '../../hooks/useGameSelection';
+import { useImageHandler } from '../../hooks/useImageHandler';
+import { postUtils } from '../../utils/postUtils';
+import { useBoardStore } from '../../../stores/useBoardStore';
+import { PostData } from '../../../types';
+
+export const useEditForm = ({ postId, onSave, onCancel }: UseEditFormProps) => {
+  const {
+    allPosts,
+    currentPost: globalCurrentPost,
+    gameList,
+  } = useBoardStore();
+
+  const [loading, setLoading] = useState<boolean>(true);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [title, setTitle] = useState<string>('');
+  const [content, setContent] = useState<string>('');
+  const [originalData, setOriginalData] = useState<PostData | null>(null);
+
+  const { validate } = useFormValidation();
+  const {
+    selectedGame,
+    setSelectedGame,
+    rating,
+    setRating: setGameSelectionRating,
+    isReviewMode,
+    setIsReviewMode,
+  } = useGameSelection();
+  const {
+    imageFile,
+    currentImageUrl,
+    isImageRemoved,
+    handleImageChange,
+    handleRemoveImage,
+    setCurrentImageUrl,
+  } = useImageHandler();
+
+  useEffect(() => {
+    setLoading(true);
+    const foundData =
+      globalCurrentPost && globalCurrentPost.postKey === postId
+        ? globalCurrentPost
+        : allPosts.find((post) => post.postKey === postId);
+
+    if (foundData) {
+      setOriginalData(foundData);
+      setTitle(foundData.postTitle);
+      setContent(foundData.postText);
+
+      setSelectedGame(foundData.game_name || '');
+      setIsReviewMode(foundData.postTopic === '후기');
+      setGameSelectionRating(
+        foundData.post_score && foundData.post_score > 0
+          ? foundData.post_score
+          : 1
+      );
+      setCurrentImageUrl(foundData.image_url || '');
+    } else {
+      console.error(`ID ${postId}의 게시글을 스토어에서 찾을 수 없습니다.`);
+      setOriginalData(null);
+    }
+    setLoading(false);
+  }, [
+    postId,
+    allPosts,
+    globalCurrentPost,
+    setSelectedGame,
+    setIsReviewMode,
+    setGameSelectionRating,
+    setCurrentImageUrl,
+  ]);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setSaving(true);
+
+      const validationError = validate(
+        {
+          title: title,
+          content: content,
+          selectedGame: selectedGame,
+          rating: rating,
+          isReviewMode: isReviewMode,
+        },
+        {
+          game: { required: isReviewMode },
+          rating: { min: isReviewMode ? 1 : 0 },
+        }
+      );
+
+      if (validationError) {
+        alert(validationError);
+        setSaving(false);
+        return;
+      }
+
+      if (!originalData) {
+        console.error(
+          '원본 게시글 데이터를 찾을 수 없어 업데이트를 저장할 수 없습니다.'
+        );
+        setSaving(false);
+        return;
+      }
+
+      const updatedData: Partial<PostData> = {
+        postTitle: title,
+        postText: content,
+        postTopic: isReviewMode ? '후기' : '자유',
+        image_url: isImageRemoved ? undefined : currentImageUrl,
+        ...(isReviewMode && {
+          game_name: selectedGame,
+          post_score: rating,
+        }),
+      };
+
+      const finalUpdatedPost = postUtils.updatePost(originalData, updatedData);
+
+      if (onSave) {
+        onSave(finalUpdatedPost);
+      }
+      setSaving(false);
+    },
+    [
+      title,
+      content,
+      selectedGame,
+      rating,
+      isReviewMode,
+      isImageRemoved,
+      currentImageUrl,
+      originalData,
+      onSave,
+      validate,
+    ]
+  );
+
+  const handleCancel = useCallback(() => {
+    if (onCancel) {
+      onCancel();
+    }
+  }, [onCancel]);
+
+  return {
+    loading,
+    saving,
+    title,
+    setTitle,
+    content,
+    setContent,
+    originalData,
+    selectedGame,
+    setSelectedGame,
+    rating,
+    setGameSelectionRating,
+    isReviewMode,
+    setIsReviewMode,
+    imageFile,
+    currentImageUrl,
+    isImageRemoved,
+    handleImageChange,
+    handleRemoveImage,
+    setCurrentImageUrl,
+    handleSubmit,
+    handleCancel,
+    gameList,
+  };
+};

--- a/digital_game_nomad/app/board/(posts)/edit/page.tsx
+++ b/digital_game_nomad/app/board/(posts)/edit/page.tsx
@@ -1,0 +1,11 @@
+// slice
+import EditContainer from './containers/Edit.container';
+import { PageProps } from './types';
+
+export default function page({ params }: PageProps) {
+  return (
+    <>
+      <EditContainer postId={params.id} />
+    </>
+  );
+}

--- a/digital_game_nomad/app/board/(posts)/edit/types/index.ts
+++ b/digital_game_nomad/app/board/(posts)/edit/types/index.ts
@@ -1,0 +1,45 @@
+import { PostData } from '@/app/board/types';
+import { TypeAndGameProps } from '../../types';
+
+export type ActionBtnsProps = {
+  saving: boolean;
+  handleCancel: () => void;
+};
+
+export type BadgeProps = {
+  topic: '자유' | '후기';
+};
+
+export type PostEditProps = {
+  postId: string;
+  onSave?: (postData: PostData) => void;
+  onCancel?: () => void;
+};
+
+export type UseEditFormProps = {
+  postId: string;
+  onSave?: (postData: PostData) => void;
+  onCancel?: () => void;
+};
+
+export type EditPresenterProps = {
+  title: string;
+  setTitle: (title: string) => void;
+  content: string;
+  setContent: (content: string) => void;
+  topic: '자유' | '후기';
+  currentImageUrl: string;
+  handleImageChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleRemoveImage: () => void;
+  handleSubmit: (e: React.FormEvent) => void;
+  handleCancel: () => void;
+  saving: boolean;
+  isReviewMode: boolean;
+  typeAndGameProps: TypeAndGameProps;
+};
+
+export type PageProps = {
+  params: {
+    id: string;
+  };
+};


### PR DESCRIPTION
### 작업 내용

- 게시글 데이터 불러오기 및 초기화 로직 구현

- 후기/자유 주제에 따라 게임 선택, 평점, 이미지 등 동적 상태 분기 처리 구현

- 게시글 수정 폼 입력값 유효성 검사 및 저장 로직 구현

- 게시글 미존재, 저장 불가 등 예외 상황 처리 및 상태 관리 구현

- 수정 취소, 이미지 변경/삭제 등 폼 액션 핸들러 구현
