### PR TITLE
Feat: 참여 신청 관리 스토어 구현

### DIFF
--- a/digital_game_nomad/shared/stores/useApplicationsStore.ts
+++ b/digital_game_nomad/shared/stores/useApplicationsStore.ts
@@ -1,0 +1,96 @@
+// package
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+// slice
+import { ApplicationsState, ApplicationData } from '../types';
+
+export const useApplicationsStore = create<ApplicationsState>()(
+  persist(
+    (set) => ({
+      applications: [],
+      addApplication: async (newApplicationWithImage) => {
+        const { imageFile, applicantEmail, ...restOfNewApplication } =
+          newApplicationWithImage;
+
+        const id = Date.now().toString();
+        const submittedAt = new Date().toISOString();
+
+        let imageData: string | undefined = undefined;
+        let hasImage = false;
+
+        if (imageFile) {
+          try {
+            const reader = new FileReader();
+            imageData = await new Promise<string>((resolve, reject) => {
+              reader.onload = () => resolve(reader.result as string);
+              reader.onerror = reject;
+              reader.readAsDataURL(imageFile);
+            });
+            hasImage = true;
+          } catch (error) {
+            console.error('이미지 변환 실패:', error);
+            hasImage = false;
+          }
+        }
+
+        const applicationToAdd: ApplicationData = {
+          id,
+          ...restOfNewApplication,
+          hasImage,
+          imageData,
+          submittedAt,
+          status: 'pending',
+          applicantEmail,
+          contactEmail: undefined,
+          contactPhone: undefined,
+          reviewedAt: undefined,
+          reviewedBy: undefined,
+          notes: undefined,
+        };
+
+        set((state) => ({
+          applications: [...state.applications, applicationToAdd],
+        }));
+      },
+      updateApplicationStatus: (id, status) =>
+        set((state) => ({
+          applications: state.applications.map((app) =>
+            app.id === id
+              ? {
+                  ...app,
+                  status,
+                  reviewedAt:
+                    status !== 'pending' ? new Date().toISOString() : undefined,
+                  reviewedBy: status !== 'pending' ? 'Admin User' : undefined,
+                }
+              : app
+          ),
+        })),
+      bulkUpdateApplicationStatus: (ids, status) =>
+        set((state) => ({
+          applications: state.applications.map((app) =>
+            ids.includes(app.id)
+              ? {
+                  ...app,
+                  status,
+                  reviewedAt:
+                    status !== 'pending' ? new Date().toISOString() : undefined,
+                  reviewedBy: status !== 'pending' ? 'Admin User' : undefined,
+                }
+              : app
+          ),
+        })),
+      deleteApplications: (ids) =>
+        set((state) => ({
+          applications: state.applications.filter(
+            (app) => !ids.includes(app.id)
+          ),
+        })),
+    }),
+    {
+      name: 'company-applications-storage',
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);

--- a/digital_game_nomad/shared/types/index.ts
+++ b/digital_game_nomad/shared/types/index.ts
@@ -209,3 +209,52 @@ export type InquiriesState = {
   saveInquiryReply: (id: string, replyContent: string) => void;
   deleteInquiries: (ids: string[]) => void;
 };
+
+export type ApplicationStatus = 'pending' | 'approved' | 'rejected';
+
+export type ApplicationData = {
+  id: string;
+  companyName: string;
+  gameName: string;
+  description: string;
+  gameUrl: string;
+  youtubeUrl: string;
+  hasImage: boolean;
+  imageData?: string;
+  submittedAt: string;
+  status: ApplicationStatus;
+  applicantEmail: string;
+  contactEmail?: string;
+  contactPhone?: string;
+  reviewedAt?: string;
+  reviewedBy?: string;
+  notes?: string;
+};
+
+export type NewApplicationInput = Omit<
+  ApplicationData,
+  | 'id'
+  | 'submittedAt'
+  | 'status'
+  | 'hasImage'
+  | 'imageData'
+  | 'reviewedAt'
+  | 'reviewedBy'
+  | 'notes'
+  | 'contactEmail'
+  | 'contactPhone'
+> & { imageFile?: File | null; applicantEmail: string };
+
+export type ApplicationsState = {
+  applications: ApplicationData[];
+  addApplication: (newApplication: NewApplicationInput) => Promise<void>;
+  updateApplicationStatus: (
+    id: string,
+    status: ApplicationData['status']
+  ) => void;
+  bulkUpdateApplicationStatus: (
+    ids: string[],
+    status: ApplicationData['status']
+  ) => void;
+  deleteApplications: (ids: string[]) => void;
+};


### PR DESCRIPTION
### 작업 내용

- 기업 게임 신청 목록 상태 관리 기능 구현

- 신규 신청 등록 기능 구현

- 신청 ID, 제출일, 상태 자동 생성

- 이미지 업로드 시 Base64 변환 후 상태 저장

- 이미지 업로드 실패 시 예외 처리 로직 추가

- 신청 상태 변경 기능 구현

- 상태 변경 시 검토일, 검토자 자동 기록

- 다중 신청 상태 일괄 변경 기능 구현

- 선택한 신청 건들의 상태 및 검토 정보 일괄 업데이트

- 신청 삭제 기능 구현