### PR TITLE
Feat: 회원가입 폼 리팩터링 및 유효성 검증/스토어 연동 기능 개선

### DIFF
--- a/digital_game_nomad/app/(auth)/register/components/PhoneInputGroup.tsx
+++ b/digital_game_nomad/app/(auth)/register/components/PhoneInputGroup.tsx
@@ -10,6 +10,7 @@ export default function PhoneInputGroup({
   phone,
   verificationCode,
   showVerification,
+  isLoading,
   isCarrierSelectOpen,
   validationPhone,
   validationPhoneVerified,
@@ -23,7 +24,7 @@ export default function PhoneInputGroup({
   return (
     <InputGroup
       label='전화번호'
-      showError={!validationPhone && phone.join('') !== ''}
+      showError={!validationPhone && phone.slice(1).join('') !== ''}
       errorMessage='유효한 전화번호 11자리를 입력해 주세요.'
       showSuccess={validationPhoneVerified}
       successMessage='전화번호 인증이 완료되었습니다'
@@ -47,7 +48,7 @@ export default function PhoneInputGroup({
               }))
             }
           >
-            <option>통신사 선택</option>
+            <option value=''>통신사 선택</option>
             <option value='SKT'>SKT</option>
             <option value='KT'>KT</option>
             <option value='LG'>LG U+</option>
@@ -61,8 +62,8 @@ export default function PhoneInputGroup({
         <div className={styles.phoneContainer__inputs}>
           <input
             type='text'
-            value={phone[0]}
-            onChange={(e) => handleInputChange('phone', e.target.value, 0)}
+            value={phone[1]}
+            onChange={(e) => handleInputChange('phone', e.target.value, 1)}
             className={styles.phoneContainer__input}
             placeholder='010'
             maxLength={3}
@@ -70,8 +71,8 @@ export default function PhoneInputGroup({
           <span className={styles.phoneContainer__separator}>-</span>
           <input
             type='text'
-            value={phone[1]}
-            onChange={(e) => handleInputChange('phone', e.target.value, 1)}
+            value={phone[2]}
+            onChange={(e) => handleInputChange('phone', e.target.value, 2)}
             className={styles.phoneContainer__input}
             placeholder='1234'
             maxLength={4}
@@ -79,8 +80,8 @@ export default function PhoneInputGroup({
           <span className={styles.phoneContainer__separator}>-</span>
           <input
             type='text'
-            value={phone[2]}
-            onChange={(e) => handleInputChange('phone', e.target.value, 2)}
+            value={phone[3]}
+            onChange={(e) => handleInputChange('phone', e.target.value, 3)}
             className={styles.phoneContainer__input}
             placeholder='5678'
             maxLength={4}
@@ -88,7 +89,12 @@ export default function PhoneInputGroup({
           <button
             type='button'
             onClick={requestVerification}
-            disabled={!validationPhone || validationPhoneVerified}
+            disabled={
+              !phone[0] ||
+              !validationPhone ||
+              validationPhoneVerified ||
+              isLoading
+            }
             className={`${styles.groupContainer__btn} ${styles.btnSuccess}`}
           >
             {validationPhoneVerified ? '인증완료' : '인증'}

--- a/digital_game_nomad/app/(auth)/register/container/RegisterContainer.tsx
+++ b/digital_game_nomad/app/(auth)/register/container/RegisterContainer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 // slice
-import RegisterPresenter from '../presenters/Register.presenter';
+import RegisterPresenter from '../presenter/RegisterPresenter';
 import { useRegisterForm } from '../hooks/useRegisterForm';
 
 export default function RegisterContainer() {

--- a/digital_game_nomad/app/(auth)/register/hooks/useFormInput.ts
+++ b/digital_game_nomad/app/(auth)/register/hooks/useFormInput.ts
@@ -5,18 +5,26 @@ import { useState, useCallback } from 'react';
 import { RegistrationFormData } from '../types';
 
 export const useFormInput = (initialData: RegistrationFormData) => {
-  const [formData, setFormData] = useState<RegistrationFormData>(initialData);
+  const [formData, setFormData] = useState<RegistrationFormData>({
+    ...initialData,
+    phone:
+      initialData.phone.length === 4 ? initialData.phone : ['', '', '', ''],
+  });
+
   const handleInputChange = useCallback(
     <T extends keyof RegistrationFormData>(
       field: T,
       value: T extends 'phone' ? string : string,
-      index?: T extends 'phone' ? number : undefined
+      index?: T extends 'phone' ? 0 | 1 | 2 | 3 : undefined
     ) => {
       setFormData((prev) => {
         if (field === 'phone' && index !== undefined) {
-          const newPhone = [...(prev.phone as string[])];
-          newPhone[index] = value;
-          return { ...prev, phone: newPhone };
+          const newPhoneTuple: [string, string, string, string] = [
+            ...prev.phone,
+          ];
+          newPhoneTuple[index] = value;
+
+          return { ...prev, phone: newPhoneTuple };
         }
         return { ...prev, [field]: value };
       });

--- a/digital_game_nomad/app/(auth)/register/hooks/usePhoneVerification.ts
+++ b/digital_game_nomad/app/(auth)/register/hooks/usePhoneVerification.ts
@@ -3,26 +3,39 @@ import { useState, useCallback } from 'react';
 
 // slice
 import { isValidPhoneFormat } from '../utils/validation';
-import { PhoneVerificationProps, ValidationState } from '../types';
+import {
+  PhoneVerificationProps,
+  ValidationState,
+  RegistrationFormData,
+} from '../types';
 
 export const usePhoneVerification = ({
   phone,
   setValidation,
   setIsLoading,
+  setFormData,
 }: PhoneVerificationProps) => {
   const [verificationCode, setVerificationCode] = useState<string>('');
   const [showVerification, setShowVerification] = useState<boolean>(false);
   const [isCarrierSelectOpen, setIsCarrierSelectOpen] =
     useState<boolean>(false);
 
-  const handleCarrierChange = useCallback(() => {
-    setIsCarrierSelectOpen(false);
-  }, []);
+  const handleCarrierChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const selectedCarrier = e.target.value;
+      setIsCarrierSelectOpen(false);
+      setFormData((prev: RegistrationFormData) => ({
+        ...prev,
+        phone: [selectedCarrier, prev.phone[1], prev.phone[2], prev.phone[3]],
+      }));
+    },
+    [setFormData]
+  );
 
   const requestVerification = useCallback(async () => {
-    if (!isValidPhoneFormat(phone.join(''))) {
-      alert('유효한 전화번호를 입력해주세요.');
-
+    const phoneDigits = phone.slice(1).join('');
+    if (!isValidPhoneFormat(phoneDigits)) {
+      alert('유효한 전화번호 11자리를 입력해주세요.');
       setValidation((prev: ValidationState) => ({ ...prev, phone: false }));
       return;
     }
@@ -34,15 +47,14 @@ export const usePhoneVerification = ({
   }, [phone, setIsLoading, setValidation]);
 
   const verifyPhone = useCallback(() => {
-    if (verificationCode.length === 4) {
+    const correctCode = '1234';
+    if (verificationCode === correctCode) {
       setValidation((prev: ValidationState) => ({
         ...prev,
         phoneVerified: true,
       }));
       setShowVerification(false);
     } else {
-      alert('유효한 인증번호 4자리를 입력해주세요.');
-
       setValidation((prev: ValidationState) => ({
         ...prev,
         phoneVerified: false,

--- a/digital_game_nomad/app/(auth)/register/hooks/useRegisterForm.ts
+++ b/digital_game_nomad/app/(auth)/register/hooks/useRegisterForm.ts
@@ -1,5 +1,6 @@
 // package
 import { useCallback, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
 
 // slice
 import { useFormInput } from './useFormInput';
@@ -8,12 +9,21 @@ import { useEmailRegistration } from './useEmailRegistration';
 import { usePhoneVerification } from './usePhoneVerification';
 import { usePasswordVisibility } from './usePasswordVisibility';
 import { useLoadingState } from './useLoadingState';
-
 import { isValidEmailFormat } from '../utils/validation';
-
 import { RegistrationFormData, UseRegisterFormReturn } from '../types';
 
+// layer
+import { useAuthStore } from '@/shared/stores/useAuthStore';
+import { useRegisteredUsersStore } from '@/shared/stores/useRegisteredUsersStore';
+
 export const useRegisterForm = (): UseRegisterFormReturn => {
+  const router = useRouter();
+  const login = useAuthStore((state) => state.login);
+  const addUser = useRegisteredUsersStore((state) => state.addUser);
+  const updateUserProfileInStore = useRegisteredUsersStore(
+    (state) => state.updateUserProfile
+  );
+
   const {
     formData,
     setFormData,
@@ -24,7 +34,7 @@ export const useRegisterForm = (): UseRegisterFormReturn => {
     passwordCheck: '',
     name: '',
     nickname: '',
-    phone: ['', '', ''],
+    phone: ['', '', '', ''],
   });
 
   const { isLoading, setIsLoading } = useLoadingState();
@@ -44,7 +54,6 @@ export const useRegisterForm = (): UseRegisterFormReturn => {
     setIsEmailSelectOpen,
     handleEmailDomainChange,
     fullEmailForValidation,
-    checkEmailDuplicate: baseCheckEmailDuplicate,
   } = useEmailRegistration({
     email: formData.email,
     setValidation,
@@ -58,47 +67,82 @@ export const useRegisterForm = (): UseRegisterFormReturn => {
     showVerification,
     isCarrierSelectOpen,
     setIsCarrierSelectOpen,
-    handleCarrierChange,
+    handleCarrierChange: baseHandleCarrierChange,
     requestVerification: baseRequestVerification,
     verifyPhone: baseVerifyPhone,
   } = usePhoneVerification({
     phone: formData.phone,
     setValidation,
     setIsLoading,
+    setFormData,
   });
 
   const handleInputChange = useCallback(
-    (field: keyof RegistrationFormData, value: string, index?: number) => {
+    (
+      field: keyof RegistrationFormData,
+      value: string,
+      index?: 0 | 1 | 2 | 3
+    ) => {
       baseHandleInputChange(field, value, index);
 
-      let currentInputtedFormData: RegistrationFormData;
-      if (field === 'phone' && index !== undefined) {
-        const newPhoneArray = [...formData.phone];
-        newPhoneArray[index] = value;
-        currentInputtedFormData = { ...formData, phone: newPhoneArray };
-      } else {
-        currentInputtedFormData = { ...formData, [field]: value as string };
-      }
+      setFormData((prevFormData) => {
+        let currentInputtedFormData: RegistrationFormData;
 
-      if (field === 'phone') {
-        validateField(
-          field,
-          currentInputtedFormData.phone,
-          currentInputtedFormData
-        );
-      } else {
-        validateField(
-          field,
-          currentInputtedFormData[field] as string,
-          currentInputtedFormData
-        );
-      }
+        if (field === 'phone' && index !== undefined) {
+          const newPhoneTuple: [string, string, string, string] = [
+            prevFormData.phone[0],
+            prevFormData.phone[1],
+            prevFormData.phone[2],
+            prevFormData.phone[3],
+          ];
+          newPhoneTuple[index] = value;
+          currentInputtedFormData = { ...prevFormData, phone: newPhoneTuple };
+        } else {
+          currentInputtedFormData = {
+            ...prevFormData,
+            [field]: value as string,
+          };
+        }
 
-      if (field === 'email' && value.includes('@')) {
-        setEmailDomain('direct');
-      }
+        if (field === 'phone') {
+          validateField(
+            field,
+            currentInputtedFormData.phone,
+            currentInputtedFormData
+          );
+        } else {
+          validateField(
+            field,
+            currentInputtedFormData[field] as string,
+            currentInputtedFormData
+          );
+        }
+
+        if (field === 'email' && value.includes('@')) {
+          setEmailDomain('direct');
+        }
+        return currentInputtedFormData;
+      });
     },
-    [baseHandleInputChange, validateField, formData, setEmailDomain]
+    [baseHandleInputChange, validateField, setEmailDomain, setFormData]
+  );
+
+  const handleCarrierChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      baseHandleCarrierChange(e);
+      setFormData((prevFormData) => {
+        const updatedPhone: [string, string, string, string] = [
+          e.target.value,
+          prevFormData.phone[1],
+          prevFormData.phone[2],
+          prevFormData.phone[3],
+        ];
+        const updatedFormData = { ...prevFormData, phone: updatedPhone };
+        validateField('phone', updatedFormData.phone, updatedFormData);
+        return updatedFormData;
+      });
+    },
+    [baseHandleCarrierChange, setFormData, validateField]
   );
 
   const setIsSelectOpen = useCallback(
@@ -124,8 +168,38 @@ export const useRegisterForm = (): UseRegisterFormReturn => {
   );
 
   const checkEmailDuplicate = useCallback(async () => {
-    await baseCheckEmailDuplicate();
-  }, [baseCheckEmailDuplicate]);
+    setIsLoading(true);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const existingUsers = useRegisteredUsersStore.getState().users;
+    const isDuplicate = existingUsers.some(
+      (user) => user.email === fullEmailForValidation
+    );
+
+    if (isDuplicate) {
+      alert('이미 사용 중인 이메일입니다.');
+      setValidation((prev: any) => ({
+        ...prev,
+        emailChecked: false,
+        email: false,
+      }));
+    } else if (!isValidEmailFormat(fullEmailForValidation)) {
+      alert('올바른 이메일 주소 형식을 입력해 주세요.');
+      setValidation((prev: any) => ({
+        ...prev,
+        emailChecked: false,
+        email: false,
+      }));
+    } else {
+      alert('사용 가능한 이메일입니다.');
+      setValidation((prev: any) => ({
+        ...prev,
+        emailChecked: true,
+        email: true,
+      }));
+    }
+    setIsLoading(false);
+  }, [fullEmailForValidation, setIsLoading, setValidation]);
 
   const requestVerification = useCallback(async () => {
     await baseRequestVerification();
@@ -152,20 +226,57 @@ export const useRegisterForm = (): UseRegisterFormReturn => {
     );
   }, [fullEmailForValidation, validation]);
 
-  const handleSubmit = useCallback(async () => {
-    const finalFormData = {
-      ...formData,
-      email: fullEmailForValidation,
-    };
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
 
-    if (!allFieldsValid) {
-      alert('모든 필수 정보를 올바르게 입력하고 인증을 완료해주세요.');
-      return;
-    }
+      if (!allFieldsValid) {
+        alert('모든 필수 정보를 올바르게 입력하고 인증을 완료해주세요.');
+        return;
+      }
 
-    console.log('폼 제출됨:', finalFormData);
-    alert('회원가입이 완료되었습니다!');
-  }, [formData, fullEmailForValidation, allFieldsValid]);
+      setIsLoading(true);
+
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+
+        addUser({
+          email: fullEmailForValidation,
+          password: formData.password,
+          userGrade: 3,
+          name: formData.name,
+          nickname: formData.nickname,
+          phone: formData.phone,
+          joinDate: new Date().toISOString().split('T')[0],
+        });
+
+        login(3, fullEmailForValidation);
+
+        updateUserProfileInStore(fullEmailForValidation, {
+          lastLoginDate: new Date().toISOString().slice(0, 10),
+        });
+
+        console.log('회원가입 및 로그인 성공:', fullEmailForValidation);
+        alert('회원가입이 완료되었습니다!');
+        router.push('/');
+      } catch (error) {
+        console.error('회원가입 처리 중 오류 발생:', error);
+        alert('회원가입에 실패했습니다. 다시 시도해주세요.');
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [
+      formData,
+      fullEmailForValidation,
+      allFieldsValid,
+      setIsLoading,
+      addUser,
+      login,
+      router,
+      updateUserProfileInStore,
+    ]
+  );
 
   const combinedIsSelectOpen = useMemo(
     () => ({

--- a/digital_game_nomad/app/(auth)/register/hooks/useValidation.ts
+++ b/digital_game_nomad/app/(auth)/register/hooks/useValidation.ts
@@ -54,7 +54,10 @@ export const useValidation = () => {
             isValid = isValidNicknameFormat(value as string);
             break;
           case 'phone':
-            isValid = isValidPhoneFormat((value as string[]).join(''));
+            const phoneDigits = (value as [string, string, string, string])
+              .slice(1)
+              .join('');
+            isValid = isValidPhoneFormat(phoneDigits);
             phoneVerified = false;
             break;
           default:

--- a/digital_game_nomad/app/(auth)/register/index.ts
+++ b/digital_game_nomad/app/(auth)/register/index.ts
@@ -1,0 +1,1 @@
+export { default as Register } from './container/RegisterContainer';

--- a/digital_game_nomad/app/(auth)/register/page.tsx
+++ b/digital_game_nomad/app/(auth)/register/page.tsx
@@ -1,10 +1,6 @@
 // slice
-import RegisterContainer from './containers/Register.container';
+import { Register } from '.';
 
 export default function page() {
-  return (
-    <>
-      <RegisterContainer />
-    </>
-  );
+  return <Register />;
 }

--- a/digital_game_nomad/app/(auth)/register/presenter/RegisterPresenter.tsx
+++ b/digital_game_nomad/app/(auth)/register/presenter/RegisterPresenter.tsx
@@ -7,9 +7,7 @@ import EmailInputGroup from '../components/EmailInputGroup';
 import PasswordInputGroup from '../components/PasswordInputGroup';
 import PhoneInputGroup from '../components/PhoneInputGroup';
 import Footer from '../components/Footer';
-
 import styles from '../styles/Register.module.scss';
-
 import { RegisterPresenterProps } from '../types';
 
 export default function RegisterPresenter({

--- a/digital_game_nomad/app/(auth)/register/types/index.ts
+++ b/digital_game_nomad/app/(auth)/register/types/index.ts
@@ -6,7 +6,7 @@ export type RegistrationFormData = {
   passwordCheck: string;
   name: string;
   nickname: string;
-  phone: string[];
+  phone: [string, string, string, string];
 };
 
 export type ValidationState = {
@@ -60,14 +60,18 @@ export type PasswordInputGroupProps = {
 };
 
 export type PhoneInputGroupProps = {
-  phone: string[];
+  phone: [string, string, string, string];
   verificationCode: string;
   showVerification: boolean;
   isLoading: boolean;
   isCarrierSelectOpen: boolean;
   validationPhone: boolean;
   validationPhoneVerified: boolean;
-  handleInputChange: (field: 'phone', value: string, index: number) => void;
+  handleInputChange: (
+    field: 'phone',
+    value: string,
+    index: 0 | 1 | 2 | 3
+  ) => void;
   handleCarrierChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   requestVerification: () => Promise<void>;
   verifyPhone: () => void;
@@ -85,9 +89,10 @@ export type EmailRegistrationProps = {
 };
 
 export type PhoneVerificationProps = {
-  phone: string[];
+  phone: [string, string, string, string];
   setValidation: Dispatch<SetStateAction<ValidationState>>;
   setIsLoading: (loading: boolean) => void;
+  setFormData: Dispatch<SetStateAction<RegistrationFormData>>;
 };
 
 export type UseRegisterFormReturn = {
@@ -103,14 +108,14 @@ export type UseRegisterFormReturn = {
   handleInputChange: (
     field: keyof RegistrationFormData,
     value: string,
-    index?: number
+    index?: 0 | 1 | 2 | 3
   ) => void;
   handleEmailDomainChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   handleCarrierChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   checkEmailDuplicate: () => Promise<void>;
   requestVerification: () => Promise<void>;
   verifyPhone: () => void;
-  handleSubmit: () => Promise<void>;
+  handleSubmit: (e: React.FormEvent) => Promise<void>;
   setShowPassword: (show: boolean) => void;
   setShowPasswordCheck: (show: boolean) => void;
   setVerificationCode: (code: string) => void;
@@ -135,14 +140,14 @@ export type RegisterPresenterProps = {
   handleInputChange: (
     field: keyof RegistrationFormData,
     value: string,
-    index?: number
+    index?: 0 | 1 | 2 | 3
   ) => void;
   handleEmailDomainChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   handleCarrierChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   checkEmailDuplicate: () => Promise<void>;
   requestVerification: () => Promise<void>;
   verifyPhone: () => void;
-  handleSubmit: () => Promise<void>;
+  handleSubmit: (e: React.FormEvent) => Promise<void>;
   setShowPassword: (show: boolean) => void;
   setShowPasswordCheck: (show: boolean) => void;
   setVerificationCode: (code: string) => void;

--- a/digital_game_nomad/app/(auth)/register/utils/validation.ts
+++ b/digital_game_nomad/app/(auth)/register/utils/validation.ts
@@ -15,5 +15,5 @@ export const isValidNameFormat = (name: string): boolean =>
 export const isValidNicknameFormat = (nickname: string): boolean =>
   /^[가-힣a-zA-Z0-9]+$/.test(nickname);
 
-export const isValidPhoneFormat = (phone: string): boolean =>
-  /^[0-9]{11}$/.test(phone);
+export const isValidPhoneFormat = (phoneDigits: string): boolean =>
+  /^\d{11}$/.test(phoneDigits);


### PR DESCRIPTION
### 작업내용

- 회원가입 폼의 전화번호 입력을 통신사 포함 4자리 튜플로 변경 및 상태 및 유효성 검사 개선

- 통신사 선택 시 상태 반영 로직 추가

- 전화번호 인증 로직에 로딩 상태 및 실제 번호만 검증하는 로직 적용

- 이메일 중복 검사 기능 스토어 기반으로 변경 및 유효성 검사 강화

- 회원가입 성공 시 유저 추가, 자동 로그인, 프로필 업데이트 및 페이지 라우팅 처리 구현

-  전화번호 검증 시 통신사 제외한 번호만 검사하도록 수정