### PR TITLE
Feat: 문의 페이지 인증 검증 로직 추가 및 스토어 연동

### DIFF
--- a/digital_game_nomad/app/support/inquiry/container/InquiryContainer.tsx
+++ b/digital_game_nomad/app/support/inquiry/container/InquiryContainer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 // slice
-import InquiryPresenter from '../presenters/Inquiry.presenter';
+import InquiryPresenter from '../presenter/InquiryPresenter';
 import { useInquirySubmission } from '../hooks/useInquirySubmission';
 
 export default function InquiryContainer() {

--- a/digital_game_nomad/app/support/inquiry/hooks/useInquirySubmission.ts
+++ b/digital_game_nomad/app/support/inquiry/hooks/useInquirySubmission.ts
@@ -4,18 +4,22 @@ import { useRouter } from 'next/navigation';
 
 // slice
 import { useForm } from './useForm';
-
 import { QuestionData, UseInquirySubmissionReturn } from '../types';
+
+// layer
+import { useInquiriesStore } from '@/shared/stores/useInquiriesStore';
+import { useAuthStore } from '@/shared/stores/useAuthStore';
 
 export function useInquirySubmission(): UseInquirySubmissionReturn {
   const router = useRouter();
-
+  const addInquiry = useInquiriesStore((state) => state.addInquiry);
+  const { userEmail: currentUserEmail, isHydrated } = useAuthStore();
   const { formData, errors, setErrors, handleInputChange, resetForm } =
     useForm<QuestionData>({
       title: '',
       text: '',
     });
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   const validateForm = (): boolean => {
     const newErrors: Partial<QuestionData> = {};
@@ -33,18 +37,28 @@ export function useInquirySubmission(): UseInquirySubmissionReturn {
   };
 
   const submitQuestion = async () => {
+    if (!isHydrated) {
+      alert('로그인 정보를 불러오는 중입니다. 잠시 후 다시 시도해 주세요.');
+      return;
+    }
+
     if (!validateForm()) return;
+
+    if (!currentUserEmail) {
+      alert('로그인 후 이용해 주세요.');
+      return;
+    }
 
     setIsSubmitting(true);
 
     try {
       await new Promise((resolve) => setTimeout(resolve, 1500));
 
-      const simulatedPostData = {
+      addInquiry({
         title: formData.title.trim(),
         text: formData.text.trim(),
-      };
-      console.log('Simulated API Call with data:', simulatedPostData);
+        senderEmail: currentUserEmail,
+      });
 
       alert('문의가 성공적으로 등록되었습니다.');
 

--- a/digital_game_nomad/app/support/inquiry/index.ts
+++ b/digital_game_nomad/app/support/inquiry/index.ts
@@ -1,0 +1,1 @@
+export { default as Inquiry } from './container/InquiryContainer';

--- a/digital_game_nomad/app/support/inquiry/page.tsx
+++ b/digital_game_nomad/app/support/inquiry/page.tsx
@@ -1,10 +1,6 @@
 // slice
-import InquiryContainer from './containers/Inquiry.container';
+import { Inquiry } from '.';
 
 export default function page() {
-  return (
-    <div>
-      <InquiryContainer />
-    </div>
-  );
+  return <Inquiry />;
 }

--- a/digital_game_nomad/app/support/inquiry/presenter/InquiryPresenter.tsx
+++ b/digital_game_nomad/app/support/inquiry/presenter/InquiryPresenter.tsx
@@ -1,6 +1,6 @@
-// components/InquiryPresenter.tsx
+// slice
 import styles from '../styles/Inquiry.module.scss';
-import FormInput from '../components/FormInput'; // Import the new components
+import FormInput from '../components/FormInput';
 import FormTextarea from '../components/FormTextarea';
 import SubmitButton from '../components/SubmitButton';
 import Header from '../components/Header';

--- a/digital_game_nomad/app/support/inquiry/types/index.ts
+++ b/digital_game_nomad/app/support/inquiry/types/index.ts
@@ -52,5 +52,5 @@ export type InquiryPresenterProps = {
   errors: Partial<QuestionData>;
   isSubmitting: boolean;
   handleInputChange: (field: keyof QuestionData, value: string) => void;
-  submitQuestion: () => void;
+  submitQuestion: () => Promise<void>;
 };


### PR DESCRIPTION
### 작업 내용

- 전역 스토어 연동으로 문의 데이터 중앙 집중 관리

- 로그인된 사용자 이메일 검증 및 인증 하이드레이션 상태 확인 로직 추가

- 비로그인 사용자 및 인증 대기 상태 처리 알림 메시지 적용

- 기존 단순 API 시뮬레이션 로직 제거 및 전역 스토어 기반 데이터 등록 흐름으로 개선

- InquiryPresenterProps의 submitQuestion 타입을 Promise<void>로 수정하여 훅 반환 타입과 일치
