### PR TITLE
Feat: 사용자 정보 및 등급 관련 유틸 함수 구현

### DIFF
--- a/digital_game_nomad/shared/utils/getCurrentUserInfo.ts
+++ b/digital_game_nomad/shared/utils/getCurrentUserInfo.ts
@@ -1,0 +1,19 @@
+// slice
+import { useAuthStore } from '../stores/useAuthStore';
+import { useRegisteredUsersStore } from '../stores/useRegisteredUsersStore';
+
+export function getCurrentUserInfo() {
+  const { userEmail, isLoggedIn } = useAuthStore.getState();
+  const users = useRegisteredUsersStore.getState().users;
+  if (!isLoggedIn || !userEmail) return null;
+
+  const foundUser = users.find((u) => u.email === userEmail);
+  if (!foundUser) return null;
+
+  return {
+    userKey: foundUser.id,
+    userName: foundUser.nickname || foundUser.name || foundUser.email,
+    userEmail: foundUser.email,
+    userGrade: foundUser.userGrade,
+  };
+}

--- a/digital_game_nomad/shared/utils/userGradeLabel.ts
+++ b/digital_game_nomad/shared/utils/userGradeLabel.ts
@@ -1,0 +1,15 @@
+export function getUserGradeLabel(userGrade?: number | string) {
+  switch (userGrade) {
+    case 1:
+    case '1':
+      return '관리자';
+    case 2:
+    case '2':
+      return '기업';
+    case 3:
+    case '3':
+      return '일반';
+    default:
+      return '';
+  }
+}


### PR DESCRIPTION
### 작업 내용

- 현재 로그인한 사용자 정보를 반환하는 함수 추가

- 전역 스토어를 활용한 현재 사용자 탐색
  
- 유저 키, 이름/닉네임, 이메일, 등급 반환

- 사용자 등급을 라벨로 변환하는 함수 추가