### PR TITLE
Feat: 게시판 상세/작성/수정 게시글 반응 상태 관리/작성 로직 개선 및 스토어 전역화 반영

### DIFF
--- a/digital_game_nomad/app/board/(posts)/hooks/useGameSelection.ts
+++ b/digital_game_nomad/app/board/(posts)/hooks/useGameSelection.ts
@@ -2,7 +2,7 @@
 import { useState, useCallback } from 'react';
 
 // slice
-import { useBoardStore } from './../../stores/useBoardStore';
+import { useBoardStore } from '@/shared/stores/useBoardStore';
 
 export function useGameSelection(
   initialGame: string = '',

--- a/digital_game_nomad/app/board/(posts)/hooks/usePostInteractions.ts
+++ b/digital_game_nomad/app/board/(posts)/hooks/usePostInteractions.ts
@@ -1,63 +1,136 @@
 // package
 import { useCallback } from 'react';
 
-// slice
-import { sessionStorageUtils } from '../utils/sessionStorageUtils';
-import { useBoardStore } from './../../stores/useBoardStore';
+// layer
+import { useBoardStore } from '@/shared/stores/useBoardStore';
+import { getCurrentUserInfo } from '@/shared/utils/getCurrentUserInfo';
 
-export const usePostInteractions = () => {
-  const { incrementViewCount, incrementLikeCount, incrementDislikeCount } =
-    useBoardStore();
+function isClient() {
+  return typeof window !== 'undefined';
+}
 
-  const handleViewCount = useCallback(
-    (postId: string) => {
-      if (!sessionStorageUtils.hasViewed(postId)) {
-        sessionStorageUtils.addViewed(postId);
-        incrementViewCount(postId);
-      }
-    },
-    [incrementViewCount]
+function getCurrentUserKey(): string {
+  const userKey = getCurrentUserInfo()?.userKey;
+  return userKey ? String(userKey) : 'guest';
+}
+
+function getLikedPostsKey(): string {
+  return `likedPosts:${getCurrentUserKey()}`;
+}
+function getDislikedPostsKey(): string {
+  return `dislikedPosts:${getCurrentUserKey()}`;
+}
+
+function getLikedPosts(): string[] {
+  if (!isClient()) return [];
+  const arr = localStorage.getItem(getLikedPostsKey());
+  try {
+    return arr ? JSON.parse(arr) : [];
+  } catch {
+    return [];
+  }
+}
+function getDislikedPosts(): string[] {
+  if (!isClient()) return [];
+  const arr = localStorage.getItem(getDislikedPostsKey());
+  try {
+    return arr ? JSON.parse(arr) : [];
+  } catch {
+    return [];
+  }
+}
+function addLikedPost(postId: string) {
+  if (!isClient()) return;
+  const liked = getLikedPosts();
+  if (!liked.includes(postId)) {
+    localStorage.setItem(
+      getLikedPostsKey(),
+      JSON.stringify([...liked, postId])
+    );
+  }
+}
+function addDislikedPost(postId: string) {
+  if (!isClient()) return;
+  const disliked = getDislikedPosts();
+  if (!disliked.includes(postId)) {
+    localStorage.setItem(
+      getDislikedPostsKey(),
+      JSON.stringify([...disliked, postId])
+    );
+  }
+}
+
+export function usePostInteractions() {
+  const incrementLikeCount = useBoardStore((state) => state.incrementLikeCount);
+  const incrementDislikeCount = useBoardStore(
+    (state) => state.incrementDislikeCount
+  );
+  const incrementViewCount = useBoardStore((state) => state.incrementViewCount);
+
+  const hasLiked = useCallback(
+    (postId: string) => getLikedPosts().includes(postId),
+    []
+  );
+  const hasDisliked = useCallback(
+    (postId: string) => getDislikedPosts().includes(postId),
+    []
+  );
+
+  const hasReacted = useCallback(
+    (postId: string) => hasLiked(postId) || hasDisliked(postId),
+    [hasLiked, hasDisliked]
   );
 
   const handleLikeClick = useCallback(
     (postId: string) => {
-      if (sessionStorageUtils.hasLiked(postId)) {
+      if (!postId) return;
+      if (hasDisliked(postId)) {
+        alert('이미 비공감한 게시글에는 추천할 수 없습니다.');
+        return;
+      }
+      if (hasLiked(postId)) {
         alert('이미 추천한 게시글입니다.');
         return;
       }
-      if (sessionStorageUtils.hasDisliked(postId)) {
-        alert('비공감한 게시글은 추천할 수 없습니다.');
-        return;
-      }
-
-      sessionStorageUtils.addLiked(postId);
       incrementLikeCount(postId);
-      alert('게시글을 추천했습니다.');
+      addLikedPost(postId);
     },
-    [incrementLikeCount]
+    [incrementLikeCount, hasLiked, hasDisliked]
   );
 
   const handleDislikeClick = useCallback(
     (postId: string) => {
-      if (sessionStorageUtils.hasDisliked(postId)) {
+      if (!postId) return;
+      if (hasLiked(postId)) {
+        alert('이미 추천한 게시글에는 비공감할 수 없습니다.');
+        return;
+      }
+      if (hasDisliked(postId)) {
         alert('이미 비공감한 게시글입니다.');
         return;
       }
-      if (sessionStorageUtils.hasLiked(postId)) {
-        alert('추천한 게시글은 비공감할 수 없습니다.');
-        return;
-      }
-
-      sessionStorageUtils.addDisliked(postId);
       incrementDislikeCount(postId);
-      alert('게시글을 비공감했습니다.');
+      addDislikedPost(postId);
     },
-    [incrementDislikeCount]
+    [incrementDislikeCount, hasLiked, hasDisliked]
   );
 
+  const handleViewCount = useCallback(
+    (postId: string) => {
+      incrementViewCount(postId);
+    },
+    [incrementViewCount]
+  );
+
+  const allPosts = useBoardStore((state) => state.allPosts);
+
   return {
-    handleViewCount,
     handleLikeClick,
     handleDislikeClick,
+    handleViewCount,
+    hasLiked,
+    hasDisliked,
+    hasReacted,
+    allPosts,
   };
-};
+}

--- a/digital_game_nomad/app/board/(posts)/utils/localStorageUtils.ts
+++ b/digital_game_nomad/app/board/(posts)/utils/localStorageUtils.ts
@@ -1,0 +1,70 @@
+export const localStorageUtils = {
+  hasViewed: (postId: string, userKey: string): boolean => {
+    const key = `viewedPosts:${userKey}`;
+    try {
+      const viewedPosts = JSON.parse(localStorage.getItem(key) || '[]');
+      return viewedPosts.includes(postId);
+    } catch {
+      return false;
+    }
+  },
+
+  addViewed: (postId: string, userKey: string) => {
+    const key = `viewedPosts:${userKey}`;
+    try {
+      const viewedPosts = JSON.parse(localStorage.getItem(key) || '[]');
+      if (!viewedPosts.includes(postId)) {
+        viewedPosts.push(postId);
+        localStorage.setItem(key, JSON.stringify(viewedPosts));
+      }
+    } catch {
+      localStorage.setItem(key, JSON.stringify([postId]));
+    }
+  },
+
+  hasLiked: (postId: string, userKey: string): boolean => {
+    const key = `likedPosts:${userKey}`;
+    try {
+      const likedPosts = JSON.parse(localStorage.getItem(key) || '[]');
+      return likedPosts.includes(postId);
+    } catch {
+      return false;
+    }
+  },
+
+  addLiked: (postId: string, userKey: string) => {
+    const key = `likedPosts:${userKey}`;
+    try {
+      const likedPosts = JSON.parse(localStorage.getItem(key) || '[]');
+      if (!likedPosts.includes(postId)) {
+        likedPosts.push(postId);
+        localStorage.setItem(key, JSON.stringify(likedPosts));
+      }
+    } catch {
+      localStorage.setItem(key, JSON.stringify([postId]));
+    }
+  },
+
+  hasDisliked: (postId: string, userKey: string): boolean => {
+    const key = `dislikedPosts:${userKey}`;
+    try {
+      const dislikedPosts = JSON.parse(localStorage.getItem(key) || '[]');
+      return dislikedPosts.includes(postId);
+    } catch {
+      return false;
+    }
+  },
+
+  addDisliked: (postId: string, userKey: string) => {
+    const key = `dislikedPosts:${userKey}`;
+    try {
+      const dislikedPosts = JSON.parse(localStorage.getItem(key) || '[]');
+      if (!dislikedPosts.includes(postId)) {
+        dislikedPosts.push(postId);
+        localStorage.setItem(key, JSON.stringify(dislikedPosts));
+      }
+    } catch {
+      localStorage.setItem(key, JSON.stringify([postId]));
+    }
+  },
+};

--- a/digital_game_nomad/app/board/(posts)/utils/postUtils.ts
+++ b/digital_game_nomad/app/board/(posts)/utils/postUtils.ts
@@ -1,4 +1,3 @@
-// slice
 import { formatDate } from './../../utils/formatDate';
 import { PostData } from './../../types';
 
@@ -14,8 +13,8 @@ export const postUtils = {
     imageUrl?: string;
     gameName?: string;
     rating?: number;
-    userKey?: number;
-    userName?: string;
+    userKey: string;
+    userName: string;
   }): PostData => {
     const basePost: PostData = {
       postKey: postUtils.generatePostKey(),
@@ -23,8 +22,7 @@ export const postUtils = {
       postText: data.content,
       postDate: formatDate(new Date().toISOString()),
       postTopic: data.topic,
-      userKey: data.userKey || 999,
-      userName: data.userName || '테스트 유저',
+      userKey: data.userKey,
       viewCount: 0,
       likeCount: 0,
       comments: 0,
@@ -38,7 +36,6 @@ export const postUtils = {
         post_score: data.rating,
       };
     }
-
     return basePost;
   },
 


### PR DESCRIPTION
### 작업 내용

- 전역 스토어 기반 사용자별 게시글 조회/추천/비추천 상태 관리 유틸 추가

- 사용자 키 단위로 반응 상태를 저장/조회하도록 구조 개선

- 게시글 생성 시 userKey, userName을 필수값으로 받아 작성자 정보 보장

- 중복된 추천/비추천 방지 및 사용자별 반응 유지 로직 구현

- 게시글 수정 시 최종 수정일 자동 갱신 처리