### PR TITLE
Feat: 게시판 상세 페이지 작성자 정보/등급 표시 및 스토어 전역화 반영

### DIFF
--- a/digital_game_nomad/app/board/(posts)/detail/components/Actions.tsx
+++ b/digital_game_nomad/app/board/(posts)/detail/components/Actions.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 // slice
 import styles from '../styles/Detail.module.scss';
 import { ActionsProps } from '../types';
@@ -15,6 +13,7 @@ export default function Actions({
       <button className={styles.navBtn} onClick={handleBackClick}>
         목록
       </button>
+
       {isAuthor && (
         <div className={styles.navBtnGroup}>
           <button

--- a/digital_game_nomad/app/board/(posts)/detail/components/CommentForm.tsx
+++ b/digital_game_nomad/app/board/(posts)/detail/components/CommentForm.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 // slice
 import styles from '../styles/Detail.module.scss';
 import { CommentFormProps } from '../types';

--- a/digital_game_nomad/app/board/(posts)/detail/components/CommentList.tsx
+++ b/digital_game_nomad/app/board/(posts)/detail/components/CommentList.tsx
@@ -1,9 +1,11 @@
-'use client';
-
 // slice
 import styles from '../styles/Detail.module.scss';
 import { CommentListProps } from '../types';
 import { formatDate } from '../../../utils/formatDate';
+
+// layer
+import { useRegisteredUsersStore } from '@/shared/stores/useRegisteredUsersStore';
+import { getUserGradeLabel } from '@/shared/utils/userGradeLabel';
 
 export default function CommentList({
   comments,
@@ -16,6 +18,8 @@ export default function CommentList({
   handleSaveEditedComment,
   handleCancelEditComment,
 }: CommentListProps) {
+  const users = useRegisteredUsersStore((state) => state.users);
+
   return (
     <div className={styles.listContainer}>
       {comments.length === 0 ? (
@@ -23,70 +27,82 @@ export default function CommentList({
           <p>아직 댓글이 없습니다.</p>
         </div>
       ) : (
-        comments.map((comment) => (
-          <div key={comment.id} className={styles.itemContainer}>
-            <div className={styles.commentHeaderContainer}>
-              <span className={styles.commentHeaderContainer__author}>
-                {comment.userName}
-              </span>
-              <span className={styles.commentHeaderContainer__date}>
-                {formatDate(comment.date)}{' '}
-                {comment.isEdited && comment.lastModifiedDate && (
-                  <span className={styles.editedIndicator}>
-                    (수정됨: {formatDate(comment.lastModifiedDate)})
-                  </span>
-                )}
-              </span>
-              {comment.userKey === loggedInUserKey && (
-                <div className={styles.commentActionsContainer}>
-                  {editingCommentId === comment.id ? (
-                    <>
-                      <button
-                        onClick={() => handleSaveEditedComment(comment.id)}
-                        className={styles.commentActionsContainer__actionBtn}
-                      >
-                        저장
-                      </button>
-                      <button
-                        onClick={handleCancelEditComment}
-                        className={styles.commentActionsContainer__actionBtn}
-                      >
-                        취소
-                      </button>
-                    </>
-                  ) : (
-                    <>
-                      <button
-                        onClick={() => handleEditCommentClick(comment)}
-                        className={styles.commentActionsContainer__btn}
-                      >
-                        수정
-                      </button>
-                      <span>|</span>
-                      <button
-                        onClick={() => handleDeleteComment(comment.id)}
-                        className={styles.commentActionsContainer__btn}
-                      >
-                        삭제
-                      </button>
-                    </>
+        comments.map((comment) => {
+          const author = users.find((u) => u.id === comment.userKey);
+          const displayName = author?.nickname || author?.name || '알수없음';
+
+          return (
+            <div key={comment.id} className={styles.itemContainer}>
+              <div className={styles.commentHeaderContainer}>
+                <span className={styles.commentHeaderContainer__author}>
+                  {displayName}
+
+                  {author && author.userGrade !== 3 && (
+                    <span className={styles.userGrade}>
+                      &nbsp;({getUserGradeLabel(author.userGrade)})
+                    </span>
                   )}
-                </div>
-              )}
+                </span>
+                <span className={styles.commentHeaderContainer__date}>
+                  {formatDate(comment.date)}{' '}
+                  {comment.isEdited && comment.lastModifiedDate && (
+                    <span className={styles.editedIndicator}>
+                      (수정됨: {formatDate(comment.lastModifiedDate)})
+                    </span>
+                  )}
+                </span>
+
+                {comment.userKey === loggedInUserKey && (
+                  <div className={styles.commentActionsContainer}>
+                    {editingCommentId === comment.id ? (
+                      <>
+                        <button
+                          onClick={() => handleSaveEditedComment(comment.id)}
+                          className={styles.commentActionsContainer__actionBtn}
+                        >
+                          저장
+                        </button>
+                        <button
+                          onClick={handleCancelEditComment}
+                          className={styles.commentActionsContainer__actionBtn}
+                        >
+                          취소
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => handleEditCommentClick(comment)}
+                          className={styles.commentActionsContainer__btn}
+                        >
+                          수정
+                        </button>
+                        <span>|</span>
+                        <button
+                          onClick={() => handleDeleteComment(comment.id)}
+                          className={styles.commentActionsContainer__btn}
+                        >
+                          삭제
+                        </button>
+                      </>
+                    )}
+                  </div>
+                )}
+              </div>
+              <div className={styles.itemContainer__content}>
+                {editingCommentId === comment.id ? (
+                  <textarea
+                    value={editedCommentContent}
+                    onChange={(e) => setEditedCommentContent(e.target.value)}
+                    rows={2}
+                  />
+                ) : (
+                  comment.content
+                )}
+              </div>
             </div>
-            <div className={styles.itemContainer__content}>
-              {editingCommentId === comment.id ? (
-                <textarea
-                  value={editedCommentContent}
-                  onChange={(e) => setEditedCommentContent(e.target.value)}
-                  rows={2}
-                />
-              ) : (
-                comment.content
-              )}
-            </div>
-          </div>
-        ))
+          );
+        })
       )}
     </div>
   );

--- a/digital_game_nomad/app/board/(posts)/detail/components/CommentSection.tsx
+++ b/digital_game_nomad/app/board/(posts)/detail/components/CommentSection.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 // slice
 import CommentForm from './CommentForm';
 import CommentList from './CommentList';

--- a/digital_game_nomad/app/board/(posts)/detail/components/Content.tsx
+++ b/digital_game_nomad/app/board/(posts)/detail/components/Content.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 // slice
 import styles from '../styles/Detail.module.scss';
 import { ContentProps } from '../types';

--- a/digital_game_nomad/app/board/(posts)/detail/components/Header.tsx
+++ b/digital_game_nomad/app/board/(posts)/detail/components/Header.tsx
@@ -1,14 +1,19 @@
-'use client';
-
 // slice
 import styles from '../styles/Detail.module.scss';
 import { HeaderProps } from '../types';
 import { formatDate } from '../../../utils/formatDate';
 
 // layer
+import { useRegisteredUsersStore } from '@/shared/stores/useRegisteredUsersStore';
+import { getUserGradeLabel } from '@/shared/utils/userGradeLabel';
 import { StarRating } from '@/features/starrating';
 
 export default function Header({ currentPost }: HeaderProps) {
+  const users = useRegisteredUsersStore((state) => state.users);
+  const author = users.find((u) => u.id === currentPost.userKey);
+  const displayName =
+    author?.nickname || author?.name || currentPost.userName || '알수없음';
+
   const isReviewPost = currentPost.postTopic === '후기';
 
   return (
@@ -43,10 +48,15 @@ export default function Header({ currentPost }: HeaderProps) {
       <div className={styles.metaContainer}>
         <div className={styles.authorContainer}>
           <span className={styles.authorContainer__name}>
-            {currentPost.userName}
+            {displayName}
+            {author && author.userGrade !== 3 && (
+              <span className={styles.userGrade}>
+                &nbsp;({getUserGradeLabel(author.userGrade)})
+              </span>
+            )}
           </span>
           <span className={styles.authorContainer__date}>
-            {formatDate(currentPost.postDate)}{' '}
+            {formatDate(currentPost.postDate)}
             {currentPost.isEdited && currentPost.lastModifiedDate && (
               <span className={styles.editedIndicator}>
                 (수정됨: {formatDate(currentPost.lastModifiedDate)})
@@ -57,10 +67,12 @@ export default function Header({ currentPost }: HeaderProps) {
 
         <div className={styles.statContainer}>
           <span className={styles.statContainer__stat}>
-            <span className={styles.statIcon}>👁</span> {currentPost.viewCount}{' '}
+            <span className={styles.statIcon}>👁</span>{' '}
+            {currentPost.viewCount ?? 0}
           </span>
           <span className={styles.statContainer__stat}>
-            <span className={styles.statIcon}>👍</span> {currentPost.likeCount}{' '}
+            <span className={styles.statIcon}>👍</span>{' '}
+            {currentPost.likeCount ?? 0}
           </span>
         </div>
       </div>

--- a/digital_game_nomad/app/board/(posts)/detail/components/Interaction.tsx
+++ b/digital_game_nomad/app/board/(posts)/detail/components/Interaction.tsx
@@ -1,30 +1,37 @@
-'use client';
-
 // slice
 import styles from '../styles/Detail.module.scss';
+import { useInteraction } from '../hooks/useInteraction';
 import { InteractionProps } from '../types';
 
-export default function Interaction({
-  likeCount,
-  dislikeCount,
-  handleLikeClick,
-  handleDislikeClick,
-}: InteractionProps) {
+export default function Interaction({ postId }: InteractionProps) {
+  const {
+    likeCount,
+    dislikeCount,
+    likeBtnClass,
+    dislikeBtnClass,
+    onLike,
+    onDislike,
+  } = useInteraction(postId);
+
   return (
-    <div className={styles.actionContainer}>
+    <div className={styles.interactionContainer}>
       <button
-        className={styles.likeBtn}
-        aria-label='게시글 추천하기'
-        onClick={handleLikeClick}
+        type='button'
+        className={`${styles.interactionBtn} ${styles[likeBtnClass]}`}
+        onClick={onLike}
+        aria-label='추천'
+        tabIndex={0}
       >
-        <span className={styles.btnIcon}>👍</span> 추천 ({likeCount})
+        <span className={styles.btnIcon}>👍</span> 추천 {likeCount}
       </button>
       <button
-        className={styles.dislikeBtn}
-        aria-label='게시글 비공감하기'
-        onClick={handleDislikeClick}
+        type='button'
+        className={`${styles.interactionBtn} ${styles[dislikeBtnClass]}`}
+        onClick={onDislike}
+        aria-label='비공감'
+        tabIndex={0}
       >
-        <span className={styles.btnIcon}>👎</span> 비공감 ({dislikeCount ?? 0})
+        <span className={styles.btnIcon}>👎</span> 비공감 {dislikeCount}
       </button>
     </div>
   );

--- a/digital_game_nomad/app/board/(posts)/detail/presenter/DetailPresenter.tsx
+++ b/digital_game_nomad/app/board/(posts)/detail/presenter/DetailPresenter.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 // slice
 import Actions from '../components/Actions';
 import Interaction from '../components/Interaction';
@@ -8,6 +6,9 @@ import Content from '../components/Content';
 import CommentSection from '../components/CommentSection';
 import styles from '../styles/Detail.module.scss';
 import { DetailPresenterProps } from '../types';
+
+// layer
+import { getCurrentUserInfo } from '@/shared/utils/getCurrentUserInfo';
 
 export default function DetailPresenter({
   currentPost,
@@ -19,12 +20,9 @@ export default function DetailPresenter({
   handleImageError,
   imageLoading,
   imageError,
-  handleLikeClick,
-  handleDislikeClick,
   handleEditClick,
   handleDeleteClick,
   handleBackClick,
-  loggedInUserKey,
   editingCommentId,
   editedCommentContent,
   setEditedCommentContent,
@@ -33,7 +31,8 @@ export default function DetailPresenter({
   handleSaveEditedComment,
   handleCancelEditComment,
 }: DetailPresenterProps) {
-  const isAuthor = currentPost.userKey === loggedInUserKey;
+  const currentUser = getCurrentUserInfo();
+  const isAuthor = !!currentUser && currentPost.userKey === currentUser.userKey;
 
   return (
     <div className={styles.detailContainer}>
@@ -43,7 +42,6 @@ export default function DetailPresenter({
           imageLoading={imageLoading}
           imageError={imageError}
         />
-
         <Content
           postText={currentPost.postText}
           imageUrl={currentPost.image_url}
@@ -52,20 +50,13 @@ export default function DetailPresenter({
           handleImageLoad={handleImageLoad}
           handleImageError={handleImageError}
         />
-
-        <Interaction
-          likeCount={currentPost.likeCount}
-          dislikeCount={currentPost.dislikeCount}
-          handleLikeClick={handleLikeClick}
-          handleDislikeClick={handleDislikeClick}
-        />
-
+        <Interaction postId={currentPost.postKey} />
         <CommentSection
           currentPostComments={currentPostComments}
           newComment={newComment}
           setNewComment={setNewComment}
           handleCommentSubmit={handleCommentSubmit}
-          loggedInUserKey={loggedInUserKey}
+          loggedInUserKey={currentUser?.userKey ?? ''}
           editingCommentId={editingCommentId}
           editedCommentContent={editedCommentContent}
           setEditedCommentContent={setEditedCommentContent}
@@ -74,7 +65,6 @@ export default function DetailPresenter({
           handleSaveEditedComment={handleSaveEditedComment}
           handleCancelEditComment={handleCancelEditComment}
         />
-
         <Actions
           isAuthor={isAuthor}
           handleBackClick={handleBackClick}

--- a/digital_game_nomad/app/board/(posts)/detail/styles/Detail.module.scss
+++ b/digital_game_nomad/app/board/(posts)/detail/styles/Detail.module.scss
@@ -192,7 +192,7 @@
       }
     }
 
-    .actionContainer {
+    .interactionContainer {
       display: flex;
       gap: 12px;
       margin-bottom: 30px;
@@ -219,6 +219,24 @@
         &:hover {
           transform: translateY(-2px);
           box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        }
+      }
+
+      .disabledBtn {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 12px 24px;
+        border: 1px solid $theme-shade-4;
+        background: $theme-shade-3;
+        border-radius: 25px;
+        cursor: pointer;
+        font-weight: 600;
+        transition: all 0.2s ease;
+        color: $theme-gray-2;
+
+        .btnIcon {
+          font-size: 18px;
         }
       }
 
@@ -362,7 +380,7 @@
 
               &:nth-child(1) {
                 background: $theme-purple-gradient;
-                color: $theme-text-1;
+                color: $theme-white;
               }
 
               &:nth-child(2) {
@@ -470,4 +488,10 @@
       }
     }
   }
+}
+
+.userGrade {
+  color: $theme-gray-3;
+  font-size: 0.95em;
+  margin-left: 2px;
 }

--- a/digital_game_nomad/app/board/(posts)/detail/types/index.ts
+++ b/digital_game_nomad/app/board/(posts)/detail/types/index.ts
@@ -15,7 +15,7 @@ export type CommentFormProps = {
 
 export type CommentListProps = {
   comments: Comment[];
-  loggedInUserKey: number;
+  loggedInUserKey: string;
   editingCommentId: number | null;
   editedCommentContent: string;
   setEditedCommentContent: (content: string) => void;
@@ -30,7 +30,7 @@ export type CommentSectionProps = {
   newComment: string;
   setNewComment: (comment: string) => void;
   handleCommentSubmit: (e: React.FormEvent) => void;
-  loggedInUserKey: number;
+  loggedInUserKey: string;
   editingCommentId: number | null;
   editedCommentContent: string;
   setEditedCommentContent: (content: string) => void;
@@ -56,10 +56,7 @@ export type HeaderProps = {
 };
 
 export type InteractionProps = {
-  likeCount: number;
-  dislikeCount: number | undefined;
-  handleLikeClick: () => void;
-  handleDislikeClick: () => void;
+  postId: string;
 };
 
 export type DetailPresenterProps = {
@@ -77,7 +74,7 @@ export type DetailPresenterProps = {
   handleEditClick: () => void;
   handleDeleteClick: () => void;
   handleBackClick: () => void;
-  loggedInUserKey: number;
+  loggedInUserKey: string;
   editingCommentId: number | null;
   editedCommentContent: string;
   setEditedCommentContent: (content: string) => void;


### PR DESCRIPTION
### 작업 내용

- 전역 스토어 연동으로 게시글/댓글 작성자 정보 조회 로직 추가

- 게시글 헤더, 댓글 목록에 작성자 닉네임 및 등급 라벨 표시 기능 구현

- Interaction 로직을 useInteraction 기반으로 리팩토링하여 상태/이벤트 관리 단순화

- getCurrentUserInfo 유틸 도입으로 현재 사용자 정보 조회 및 작성자 여부 판단 로직 개선

- 게시글 목록/상세 화면에서 최신 사용자 데이터 및 상호작용 상태 반영 시 자동 업데이트되는 구조로 개선