### PR TITLE
Fix: 게시글 수정 페이지 async로 변경 및 params 비동기 처리로 수정

### DIFF
--- a/digital_game_nomad/app/board/(posts)/edit/page.tsx
+++ b/digital_game_nomad/app/board/(posts)/edit/page.tsx
@@ -1,7 +1,11 @@
 // slice
 import { Edit } from '.';
-import { PageProps } from './types';
 
-export default function page({ params }: PageProps) {
-  return <Edit postId={params.id} />;
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <Edit postId={id} />;
 }

--- a/digital_game_nomad/app/board/(posts)/edit/types/index.ts
+++ b/digital_game_nomad/app/board/(posts)/edit/types/index.ts
@@ -37,9 +37,3 @@ export type EditPresenterProps = {
   isReviewMode: boolean;
   typeAndGameProps: TypeAndGameProps;
 };
-
-export type PageProps = {
-  params: {
-    id: string;
-  };
-};


### PR DESCRIPTION
### 작업 내용

- Page 컴포넌트를 async 함수로 변경

- params를 Promise<{ id: string }> 형태로 받아 await 처리하도록 수정

- postId 전달 로직을 비동기 처리에 맞게 개선