### PR TITLE
Fix: ForgotPasswordData import 경로 (unauth) 구조에 맞게 수정

### DIFF
--- a/digital_game_nomad/shared/types/index.ts
+++ b/digital_game_nomad/shared/types/index.ts
@@ -1,6 +1,6 @@
 import { RefObject } from 'react';
 import { FormData as ResetPasswordData } from '@/app/(auth)/reset-password/types';
-import { FormData as ForgotPasswordData } from '@/app/(auth)/forgot-password/types';
+import { FormData as ForgotPasswordData } from '@/app/(unauth)/forgot-password/types';
 import { FormData as ResetPhoneData } from '@/app/(auth)/reset-phone/types';
 
 export type UseIntersectionVisibilityOptions = {


### PR DESCRIPTION
### 작업 내용
- forgot-password 페이지 타입 정의에서 FormData import 경로 (auth)에서 (unauth)로 수정

- 타입 경로를 실제 라우트 구조와 일치시켜 가독성과 유지보수성 개선