### PR TITLE
Fix: 모바일 브라우저 비디오 배경 재생 및 노출 문제 수정

### DIFF
--- a/digital_game_nomad/shared/ui/background/videoBackground/VideoBackground.tsx
+++ b/digital_game_nomad/shared/ui/background/videoBackground/VideoBackground.tsx
@@ -3,7 +3,20 @@ import styles from './VidoeBackground.module.scss';
 
 export default function Video() {
   return (
-    <video className={styles.video} autoPlay muted loop>
+    <video
+      className={styles.video}
+      autoPlay
+      muted={true}
+      loop
+      playsInline
+      controls={false}
+      disablePictureInPicture
+      aria-hidden='true'
+      webkit-playsinline='true'
+      x5-playsinline='true'
+      preload='auto'
+      poster='/images/network.jpg'
+    >
       <source src='/videos/network.mp4' type='video/mp4' />
     </video>
   );

--- a/digital_game_nomad/shared/ui/background/videoBackground/VidoeBackground.module.scss
+++ b/digital_game_nomad/shared/ui/background/videoBackground/VidoeBackground.module.scss
@@ -5,4 +5,5 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  pointer-events: none;
 }


### PR DESCRIPTION
### 작업 내용

- iOS Safari 자동 전체화면 전환 방지를 위해 playsInline, webkit-playsinline, x5-playsinline 속성 추가

- React autoplay 정책 대응을 위해 muted={true} 명시

- 비디오 로드 이전 빈 영역 방지를 위해 poster 및 preload='auto' 속성 추가

- 불필요한 컨트롤 UI 및 PIP 기능 비활성화를 위한 controls={false}, disablePictureInPicture 속성 추가

### 관련 이슈

- #211